### PR TITLE
DCE implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ Edit webpack.config.js:
   ]
 ```
 
+## Optimizations
+
+### Dead code elemination
+
+This is an experimental feature and thus not activated by default.
+
+You can activate it by passing `dce=1` to the import and by specifying manually (for now) the exported elements you use, like the following example:
+
+```js
+import createInstance from "./add.wasm?dce=1&add&test"
+
+createInstance()
+.then(m => {
+  console.log(m.instance.exports.add(1, 2));
+  console.log(m.instance.exports.test());
+});
+```
+
+Everything else in the `add.wasm` binary will be removed.
+
 ## Include wasm from your code
 
 Grab your pre-built wasm file. For demo purposes we will use the excellent [WasmExplorer](https://mbebenita.github.io/WasmExplorer/).

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(buffer) {
 
   var params = {};
 
-  if (this.resourceQuery !== "") {
+  if (typeof this.resourceQuery === "string" && this.resourceQuery !== "") {
     params = loaderUtils.parseQuery(this.resourceQuery);
   }
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,12 @@ var loaderUtils = require('loader-utils');
 var wasmDCE = require('wasm-dce')
 
 module.exports = function(buffer) {
-  var params = loaderUtils.parseQuery(this.resourceQuery);
+
+  var params = {};
+
+  if (this.resourceQuery !== "") {
+    params = loaderUtils.parseQuery(this.resourceQuery);
+  }
 
   if (params.dce === '1') {
     // FIXME(sven): get the used exports

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@ var bootstrap = fs.readFileSync(__dirname + '/output.js', 'utf8');
 var loaderUtils = require('loader-utils');
 var wasmDCE = require('wasm-dce')
 
-var config = {dce: true};
-
 module.exports = function(buffer) {
   var params = loaderUtils.parseQuery(this.resourceQuery);
 

--- a/index.js
+++ b/index.js
@@ -10,13 +10,16 @@ module.exports = function(buffer) {
   if (this.resourceQuery !== "") {
     params = loaderUtils.parseQuery(this.resourceQuery);
 
-    var usedExports = Object
-      .keys(params)
-      .filter((flagName) => (
-        params[flagName] === true
-      ));
+    if (params.dce === '1') {
 
-    buffer = wasmDCE(buffer, usedExports);
+      var usedExports = Object
+        .keys(params)
+        .filter((flagName) => (
+          params[flagName] === true
+        ));
+
+      buffer = wasmDCE(buffer, usedExports);
+    }
   }
 
   var out = "var buffer = new ArrayBuffer(" + buffer.length + ");";

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(buffer) {
 
   var params = {};
 
-  if (typeof this.resourceQuery === "string" && this.resourceQuery !== "") {
+  if (this.resourceQuery !== "") {
     params = loaderUtils.parseQuery(this.resourceQuery);
   }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,20 @@
 var fs = require('fs');
 var bootstrap = fs.readFileSync(__dirname + '/output.js', 'utf8');
+var loaderUtils = require('loader-utils');
+var wasmDCE = require('wasm-dce')
+
+var config = {dce: true};
 
 module.exports = function(buffer) {
+  var params = loaderUtils.parseQuery(this.resourceQuery);
+
+  if (params.dce === '1') {
+    // FIXME(sven): get the used exports
+    var usedExports = [];
+
+    buffer = wasmDCE(buffer, usedExports);
+  }
+
   var out = "var buffer = new ArrayBuffer(" + buffer.length + ");";
   out += "var uint8 = new Uint8Array(buffer);";
   out += "uint8.set([";

--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@ module.exports = function(buffer) {
 
   if (this.resourceQuery !== "") {
     params = loaderUtils.parseQuery(this.resourceQuery);
-  }
 
-  if (params.dce === '1') {
-    // FIXME(sven): get the used exports
-    var usedExports = [];
+    var usedExports = Object
+      .keys(params)
+      .filter((flagName) => (
+        params[flagName] === true
+      ));
 
     buffer = wasmDCE(buffer, usedExports);
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   "homepage": "https://github.com/ballercat/wasm-loader#readme",
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "wasm-dce": "0.0.7"
+    "wasm-dce": "^1.0.0"
+  },
+  "peerDependencies": {
+    "wasm-dce": "1.x"
   },
   "devDependencies": {
     "jasmine": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/ballercat/wasm-loader#readme",
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "wasm-dce": "0.0.4"
+    "wasm-dce": "0.0.5"
   },
   "devDependencies": {
     "jasmine": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/ballercat/wasm-loader#readme",
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "wasm-dce": "0.0.5"
+    "wasm-dce": "0.0.7"
   },
   "devDependencies": {
     "jasmine": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "homepage": "https://github.com/ballercat/wasm-loader#readme",
   "dependencies": {
+    "loader-utils": "^1.1.0",
+    "wasm-dce": "0.0.3"
   },
   "devDependencies": {
     "jasmine": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/ballercat/wasm-loader#readme",
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "wasm-dce": "0.0.3"
+    "wasm-dce": "0.0.4"
   },
   "devDependencies": {
     "jasmine": "^2.6.0"

--- a/spec/wasm-loader-spec.js
+++ b/spec/wasm-loader-spec.js
@@ -53,5 +53,28 @@ describe('wasm-loader', () => {
 
     loader.call(loaderContext, wasm);
   });
+
+  describe('optimizations', () => {
+
+    it('should remove the exports if unused', (done) => {
+      loaderContext.resourceQuery = "?foo,bar";
+
+      loaderContext.callback = (unused, output) => {
+        const module = new Module(__NOTAREALMODULE__, null);
+        module._compile(output, __NOTAREALMODULE__);
+        const makeModule = module.exports();
+
+        makeModule.then(res => {
+          expect(res.instance.exports._Z4facti).not.toBe('function');
+        });
+
+        done();
+      }
+
+      loader.call(loaderContext, wasm);
+    });
+
+  });
+
 });
 

--- a/spec/wasm-loader-spec.js
+++ b/spec/wasm-loader-spec.js
@@ -65,10 +65,11 @@ describe('wasm-loader', () => {
         const makeModule = module.exports();
 
         makeModule.then(res => {
-          expect(res.instance.exports._Z4facti).not.toBe('function');
-        });
+          const factorial = res.instance.exports._Z4facti;
+          expect(factorial).not.toBe('function');
 
-        done();
+          done();
+        });
       }
 
       loader.call(loaderContext, wasm);

--- a/spec/wasm-loader-spec.js
+++ b/spec/wasm-loader-spec.js
@@ -18,6 +18,7 @@ describe('wasm-loader', () => {
 
   beforeEach(() => {
     loaderContext = {
+      resourceQuery: '',
       resourcePath: './counter.wasm',
       options: { context: __dirname + '/../' }
     };

--- a/spec/wasm-loader-spec.js
+++ b/spec/wasm-loader-spec.js
@@ -57,7 +57,7 @@ describe('wasm-loader', () => {
   describe('optimizations', () => {
 
     it('should remove the exports if unused', (done) => {
-      loaderContext.resourceQuery = "?foo,bar";
+      loaderContext.resourceQuery = "?dce=1&foo&bar";
 
       loaderContext.callback = (unused, output) => {
         const module = new Module(__NOTAREALMODULE__, null);


### PR DESCRIPTION
I wanted to submit that PR now to have some early feedback. It's far from finished, i'm missing some Webpack skills, do you know how we can access the file importing the binary (as AST or source)?

~~Currently the loader adds the binary each time you import it, we can safely remove what is not used in the binary~~

All the DCE logic is in [xtuc/wasm-dce](https://github.com/xtuc/wasm-dce).

It's _very experimental_, that's why I decided to use a feature flag `dce=1|0`. We can change it later.

## Example

**Before** [module.wasm](https://webassembly.js.org/share.html#0,97,115,109,1,0,0,0,1,7,1,96,2,127,127,1,127,3,2,1,0,7,7,1,3,97,100,100,0,0,10,9,1,7,0,32,0,32,1,106,11).

index.js:

```js
import makeAdd from "./add.wasm?dce=1"

makeAdd().then(instance => {
// ...
});
```

And **after** [module.wasm](https://webassembly.js.org/share.html#0,97,115,109,1,0,0,0,1,4,1,96,0,0,3,2,1,0,10,4,1,2,0,11,0,10,4,110,97,109,101,2,3,1,0,0).

If we detect that `instance.exports.add` is not used we can remove it from the binary.